### PR TITLE
Stats endpoint: retrieve objects count

### DIFF
--- a/api/v1/app.py
+++ b/api/v1/app.py
@@ -21,5 +21,4 @@ def teardown_appcontext(exception):
 if __name__ == "__main__":
     HBNB_API_HOST = getenv('HBNB_API_HOST')
     HBNB_API_PORT = getenv('HBNB_API_PORT')
-    app.run(host=HBNB_API_HOST, port=HBNB_API_PORT,
-            threaded=True, debug=True)
+    app.run(host=HBNB_API_HOST, port=HBNB_API_PORT, threaded=True)

--- a/api/v1/views/index.py
+++ b/api/v1/views/index.py
@@ -3,9 +3,26 @@
 """
 
 from api.v1.views import app_views
+from models.amenity import Amenity
+from models.city import City
+from models.place import Place
+from models.review import Review
+from models.state import State
+from models.user import User
+from flask import jsonify
+from models import storage
 
 
 @app_views.route('/status', strict_slashes=False)
 def status():
     """ return status """
     return {"status": "OK"}
+
+
+@app_views.route('/stats', strict_slashes=False)
+def stats():
+    """retrieves the number of each objects by type
+    """
+    objects = {"amenities": Amenity, "cities": City, "places": Place,
+               "reviews": Review, "states": State, "users": User}
+    return jsonify({key: storage.count(obj) for key, obj in objects.items()})


### PR DESCRIPTION
Created an endpoint that retrieves the number of each objects by type

remove the debug=True parameter for the app.run function